### PR TITLE
Enable toggleable mock data for dashboard endpoints

### DIFF
--- a/src/main/java/com/qtick/mis/service/DashboardService.java
+++ b/src/main/java/com/qtick/mis/service/DashboardService.java
@@ -21,6 +21,7 @@ import com.qtick.mis.security.TenantContextHolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
@@ -33,8 +34,14 @@ import java.util.Optional;
 
 @Service
 public class DashboardService {
-    
+
     private static final Logger logger = LoggerFactory.getLogger(DashboardService.class);
+
+    @Value("${app.use-mock-data:false}")
+    private boolean useMockData;
+
+    @Autowired
+    private MockDashboardService mockDashboardService;
     
     @Autowired
     private DashboardSnapshotRepository snapshotRepository;
@@ -60,8 +67,11 @@ public class DashboardService {
     /**
      * Get dashboard summary with KPI calculations and comparison logic
      */
-    public DashboardSummaryDto getSummary(LocalDate startDate, LocalDate endDate, 
+    public DashboardSummaryDto getSummary(LocalDate startDate, LocalDate endDate,
                                          LocalDate comparisonStartDate, LocalDate comparisonEndDate) {
+        if (useMockData) {
+            return mockDashboardService.getSummary(startDate, endDate, comparisonStartDate, comparisonEndDate);
+        }
         TenantContext context = TenantContextHolder.getContext();
         Long bizId = context.getBizId();
         
@@ -100,6 +110,9 @@ public class DashboardService {
      * Get trend data with time series data aggregation
      */
     public List<TrendDataDto> getTrends(String metric, LocalDate startDate, LocalDate endDate, String period) {
+        if (useMockData) {
+            return mockDashboardService.getTrends(metric, startDate, endDate, period);
+        }
         TenantContext context = TenantContextHolder.getContext();
         Long bizId = context.getBizId();
         
@@ -155,8 +168,11 @@ public class DashboardService {
     /**
      * Get top services with ranking algorithms
      */
-    public List<TopServiceDto> getTopServices(LocalDate startDate, LocalDate endDate, 
+    public List<TopServiceDto> getTopServices(LocalDate startDate, LocalDate endDate,
                                             String sortBy, Integer limit) {
+        if (useMockData) {
+            return mockDashboardService.getTopServices(startDate, endDate, sortBy, limit);
+        }
         TenantContext context = TenantContextHolder.getContext();
         Long bizId = context.getBizId();
         
@@ -197,8 +213,11 @@ public class DashboardService {
     /**
      * Get top staff with performance metrics
      */
-    public List<TopStaffDto> getTopStaff(LocalDate startDate, LocalDate endDate, 
+    public List<TopStaffDto> getTopStaff(LocalDate startDate, LocalDate endDate,
                                        String sortBy, Integer limit) {
+        if (useMockData) {
+            return mockDashboardService.getTopStaff(startDate, endDate, sortBy, limit);
+        }
         TenantContext context = TenantContextHolder.getContext();
         Long bizId = context.getBizId();
         
@@ -229,6 +248,9 @@ public class DashboardService {
      * Get business details with daily job statistics
      */
     public List<BusinessDetailsDto> getBusinessDetails(String businessType, LocalDate date) {
+        if (useMockData) {
+            return mockDashboardService.getBusinessDetails(businessType, date);
+        }
         TenantContext context = TenantContextHolder.getContext();
         Long bizId = context.getBizId();
         
@@ -261,6 +283,9 @@ public class DashboardService {
     }
 
     public BusinessViewCountDto getBusinessViewCount(LocalDate startDate, LocalDate endDate) {
+        if (useMockData) {
+            return mockDashboardService.getBusinessViewCount(startDate, endDate);
+        }
         TenantContext context = TenantContextHolder.getContext();
         Long bizId = context.getBizId();
 

--- a/src/main/java/com/qtick/mis/service/MockDashboardService.java
+++ b/src/main/java/com/qtick/mis/service/MockDashboardService.java
@@ -1,0 +1,126 @@
+package com.qtick.mis.service;
+
+import com.qtick.mis.dto.dashboard.*;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * Provides in-memory mock data for dashboard endpoints when database access is disabled.
+ */
+@Service
+public class MockDashboardService {
+
+    private final DashboardSummaryDto summary;
+    private final List<TrendDataDto> trends;
+    private final List<TopServiceDto> topServices;
+    private final List<TopStaffDto> topStaff;
+    private final List<BusinessDetailsDto> businessDetails;
+    private final BusinessViewCountDto viewCount;
+
+    public MockDashboardService() {
+        summary = new DashboardSummaryDto(
+                new BigDecimal("12500.00"),
+                new BigDecimal("11250.00"),
+                150,
+                new BigDecimal("83.33"),
+                25,
+                200,
+                12,
+                75,
+                40
+        );
+
+        trends = List.of(
+                new TrendDataDto(LocalDate.now().minusDays(2), "grosssales", new BigDecimal("3000"), "day"),
+                new TrendDataDto(LocalDate.now().minusDays(1), "grosssales", new BigDecimal("4000"), "day"),
+                new TrendDataDto(LocalDate.now(), "grosssales", new BigDecimal("5000"), "day")
+        );
+
+        TopServiceDto service1 = new TopServiceDto(1L, "Consultation", new BigDecimal("3000"), 30, new BigDecimal("100"));
+        service1.setRank(1);
+        TopServiceDto service2 = new TopServiceDto(2L, "Therapy Session", new BigDecimal("2500"), 25, new BigDecimal("100"));
+        service2.setRank(2);
+        TopServiceDto service3 = new TopServiceDto(3L, "Medication", new BigDecimal("2000"), 20, new BigDecimal("100"));
+        service3.setRank(3);
+        topServices = List.of(service1, service2, service3);
+
+        TopStaffDto staff1 = new TopStaffDto(1L, "Alice", new BigDecimal("3500"), 35, new BigDecimal("4.9"));
+        staff1.setRank(1);
+        TopStaffDto staff2 = new TopStaffDto(2L, "Bob", new BigDecimal("3000"), 30, new BigDecimal("4.7"));
+        staff2.setRank(2);
+        TopStaffDto staff3 = new TopStaffDto(3L, "Charlie", new BigDecimal("2500"), 25, new BigDecimal("4.5"));
+        staff3.setRank(3);
+        topStaff = List.of(staff1, staff2, staff3);
+
+        List<ServiceBreakdownDto> breakdown1 = List.of(
+                new ServiceBreakdownDto("Consultation", 10, 5, 12, new BigDecimal("1200")),
+                new ServiceBreakdownDto("Therapy Session", 8, 4, 10, new BigDecimal("1000"))
+        );
+        DailyJobStatsDto stats1 = new DailyJobStatsDto(LocalDate.now(), 15, 10, 20, new BigDecimal("2200"));
+        stats1.setServiceBreakdown(breakdown1);
+        BusinessDetailsDto business1 = new BusinessDetailsDto(101L, "Acme Clinic", "Healthcare");
+        business1.setContactPerson("Dr. Jane");
+        business1.setPhone("123456789");
+        business1.setEmail("jane@acme.com");
+        business1.setLastVisit(LocalDate.now().minusDays(1));
+        business1.setDailyStats(stats1);
+
+        List<ServiceBreakdownDto> breakdown2 = List.of(
+                new ServiceBreakdownDto("Medication", 5, 3, 7, new BigDecimal("700")),
+                new ServiceBreakdownDto("Consultation", 6, 2, 8, new BigDecimal("800"))
+        );
+        DailyJobStatsDto stats2 = new DailyJobStatsDto(LocalDate.now(), 12, 6, 15, new BigDecimal("1500"));
+        stats2.setServiceBreakdown(breakdown2);
+        BusinessDetailsDto business2 = new BusinessDetailsDto(102L, "Globex Pharmacy", "Retail");
+        business2.setContactPerson("Mr. Smith");
+        business2.setPhone("987654321");
+        business2.setEmail("smith@globex.com");
+        business2.setLastVisit(LocalDate.now().minusDays(3));
+        business2.setDailyStats(stats2);
+
+        businessDetails = List.of(business1, business2);
+
+        viewCount = new BusinessViewCountDto();
+        viewCount.setBizId(1L);
+        viewCount.setStartDate(LocalDate.now().minusDays(2));
+        viewCount.setEndDate(LocalDate.now());
+        viewCount.setServed(120);
+        viewCount.setSales(5000.0);
+        viewCount.setNetSales(4500.0);
+        viewCount.setQueued(30);
+        viewCount.setMissed(5);
+        viewCount.setLeftQ(2);
+        viewCount.setCancelled(1);
+        viewCount.setViewCount(150);
+    }
+
+    public DashboardSummaryDto getSummary(LocalDate startDate, LocalDate endDate,
+                                          LocalDate comparisonStartDate, LocalDate comparisonEndDate) {
+        return summary;
+    }
+
+    public List<TrendDataDto> getTrends(String metric, LocalDate startDate, LocalDate endDate, String period) {
+        return trends;
+    }
+
+    public List<TopServiceDto> getTopServices(LocalDate startDate, LocalDate endDate,
+                                              String sortBy, Integer limit) {
+        return topServices;
+    }
+
+    public List<TopStaffDto> getTopStaff(LocalDate startDate, LocalDate endDate,
+                                         String sortBy, Integer limit) {
+        return topStaff;
+    }
+
+    public List<BusinessDetailsDto> getBusinessDetails(String businessType, LocalDate date) {
+        return businessDetails;
+    }
+
+    public BusinessViewCountDto getBusinessViewCount(LocalDate startDate, LocalDate endDate) {
+        return viewCount;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -70,3 +70,6 @@ springdoc:
   swagger-ui:
     path: /swagger-ui.html
     operationsSorter: method
+
+app:
+  use-mock-data: false

--- a/src/test/java/com/qtick/mis/service/MockDashboardServiceTest.java
+++ b/src/test/java/com/qtick/mis/service/MockDashboardServiceTest.java
@@ -1,0 +1,65 @@
+package com.qtick.mis.service;
+
+import com.qtick.mis.dto.dashboard.*;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link MockDashboardService} and the mock data toggle in {@link DashboardService}.
+ */
+public class MockDashboardServiceTest {
+
+    @Test
+    void getSummaryReturnsMockData() {
+        MockDashboardService service = new MockDashboardService();
+        DashboardSummaryDto dto = service.getSummary(LocalDate.now(), LocalDate.now(), null, null);
+        assertEquals(new BigDecimal("12500.00"), dto.getGrossSales());
+        assertEquals(150, dto.getBills());
+    }
+
+    @Test
+    void getTopServicesReturnsMockData() {
+        MockDashboardService service = new MockDashboardService();
+        List<TopServiceDto> services = service.getTopServices(LocalDate.now().minusDays(2), LocalDate.now(), "revenue", 5);
+        assertEquals(3, services.size());
+        assertEquals("Consultation", services.get(0).getServiceName());
+    }
+
+    @Test
+    void businessDetailsIncludeServiceBreakdown() {
+        MockDashboardService service = new MockDashboardService();
+        List<BusinessDetailsDto> details = service.getBusinessDetails("Healthcare", LocalDate.now());
+        assertFalse(details.isEmpty());
+        DailyJobStatsDto stats = details.get(0).getDailyStats();
+        assertNotNull(stats);
+        assertEquals(2, stats.getServiceBreakdown().size());
+    }
+
+    @Test
+    void getBusinessViewCountReturnsMockData() {
+        MockDashboardService service = new MockDashboardService();
+        BusinessViewCountDto dto = service.getBusinessViewCount(LocalDate.now().minusDays(2), LocalDate.now());
+        assertEquals(120, dto.getServed());
+        assertEquals(150, dto.getViewCount());
+    }
+
+    @Test
+    void dashboardServiceUsesMockWhenEnabled() {
+        MockDashboardService mockService = new MockDashboardService();
+        DashboardService service = new DashboardService();
+        ReflectionTestUtils.setField(service, "useMockData", true);
+        ReflectionTestUtils.setField(service, "mockDashboardService", mockService);
+
+        DashboardSummaryDto dto = service.getSummary(LocalDate.now(), LocalDate.now(), null, null);
+        assertEquals(new BigDecimal("12500.00"), dto.getGrossSales());
+
+        BusinessViewCountDto viewDto = service.getBusinessViewCount(LocalDate.now().minusDays(2), LocalDate.now());
+        assertEquals(120, viewDto.getServed());
+    }
+}


### PR DESCRIPTION
## Summary
- add `use-mock-data` flag and mock dashboard service
- default flag property in configuration
- unit test validating mock service and flag delegation
- expand mock dataset to include business, staff, service and day_q_report figures

## Testing
- `gradle test` *(fails: Plugin [id: 'org.springframework.boot', version: '3.2.0'] was not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b502d42d2c832eaf0bfdd98367720a